### PR TITLE
WIP: Create pipeline definition

### DIFF
--- a/DataPipeline/PostgresqlRdsToRedshift/dbconv_psqlRDStoRedshift.sh
+++ b/DataPipeline/PostgresqlRdsToRedshift/dbconv_psqlRDStoRedshift.sh
@@ -94,7 +94,14 @@ echo "(Optional) REDShift Data Insert Mode: $REDIns"
 set -e
 
 #1. Install PSQL client that matches the version of your Postgresql Source and target Redshift
-sudo yum install mysql postgresql93 -y
+#sudo yum install mysql postgresql93 -y
+
+
+sudo rpm -ivh --force https://yum.postgresql.org/testing/10/redhat/rhel-6-x86_64/postgresql10-libs-10.7-2PGDG.rhel6.x86_64.rpm
+sudo rpm -ivh --force https://yum.postgresql.org/testing/10/redhat/rhel-6-x86_64/postgresql10-10.7-2PGDG.rhel6.x86_64.rpm
+
+
+
 
 
 #2. Parse RDS Jdbc Connect String

--- a/DataPipeline/PostgresqlRdsToRedshift/myValues.json
+++ b/DataPipeline/PostgresqlRdsToRedshift/myValues.json
@@ -1,0 +1,17 @@
+{
+  "values": {
+    "myRedshiftUsername": "rds_to_redshift_test",
+    "myRDSUsername": "mosaics_r",
+    "myS3StagingLoc": "s3://data-pipeline-ew1/",
+    "myRedshiftJdbcConnectStr": "jdbc:redshift://redshift-ew1-mosaics.cbqggadp6kz1.eu-west-1.redshift.amazonaws.com:5439/rds_to_redshift_test",
+    "*myRedshiftPassword": "bitwarden",
+    "myInsertMode": "APPEND",
+    "myRDSJdbcConnectStr": "jdbc:postgresql://rds-ew1-d-mosaics.ckhnnyqylbgj.eu-west-1.rds.amazonaws.com:5432/mosaics",
+    "*myRDSPassword": "bitwarden",
+    "myRedshiftTableName": "mytesttable",
+    "myRDSTableName": "ref.devices",
+    "myRedshiftTablePrimaryKey": "mytestpk",
+    "myRDSRedshiftSecurityGrps": ["dev-setup", "instances-api"],
+    "myRedshiftTypeConvOverrideMap": ""
+  }
+}

--- a/DataPipeline/PostgresqlRdsToRedshift/postgresqlRDS-to-Redshift-definition.json
+++ b/DataPipeline/PostgresqlRdsToRedshift/postgresqlRDS-to-Redshift-definition.json
@@ -14,7 +14,7 @@
       "name": "S3ToRedshiftCopyActivity",
       "id": "S3ToRedshiftCopyActivity",
       "runsOn": {
-        "ref": "myEc2Instance"
+        "ref": "Ec2Instance"
       },
       "type": "RedshiftCopyActivity",
       "insertMode": "#{myInsertMode}"
@@ -30,7 +30,7 @@
       "name": "RDSToS3CopyActivity",
       "id": "RDSToS3CopyActivity",
       "runsOn": {
-        "ref": "myEc2Instance"
+        "ref": "Ec2Instance"
       },
       "type": "CopyActivity"
     },
@@ -58,7 +58,7 @@
       "input": {
         "ref": "SrcRDSTable"
       },
-      "scriptUri": "s3://testbucket/scripts/dbconv_psqlRDStoRedshift.sh",
+      "scriptUri": "s3://data-pipeline-ew1/dbconv_psqlRDStoRedshift.sh",
       "dependsOn": {
         "ref": "RDSToS3CopyActivity"
       },
@@ -79,7 +79,7 @@
       ],
       "id": "RedshiftTableCreateActivity",
       "runsOn": {
-        "ref": "myEc2Instance"
+        "ref": "Ec2Instance"
       },
       "type": "ShellCommandActivity"
     },
@@ -95,24 +95,21 @@
       "name": "S3StagingCleanupActivity",
       "id": "S3StagingCleanupActivity",
       "runsOn": {
-        "ref": "myEc2Instance"
+        "ref": "Ec2Instance"
       },
       "type": "ShellCommandActivity",
       "command": "(sudo yum -y update aws-cli) && (aws s3 rm #{input.directoryPath} --recursive)"
     },
     {
       "myComment" : "Your Ec2 resource to run your pipeline activities. keyPair,subnetId and securityGroupIds are optional, if used please refer yours",
-      "subnetId": "subnet-7b3a9f46",
-      "securityGroupIds": [
-        "sg-f3973b95",
-        "sg-068b2160"
-      ],
-      "instanceType": "m3.medium",
-      "name": "myEc2Instance",
-      "keyPair": "ec2-VA-keypair",
-      "id": "myEc2Instance",
+      "instanceType": "t1.micro",
+      "name": "Ec2Instance",
+      "id": "Ec2Instance",
       "type": "Ec2Resource",
-      "terminateAfter": "2 Hours"
+      "subnetId": "subnet-08f915d2d9942f119",
+      "securityGroupIds": ["sg-05702ea580ddf5622", "sg-0e5843fba4d022ccc"],
+      "keyPair": "caribou-mosaics-dev",
+      "terminateAfter": "10 Hours"
     },
     {
       "myComment" : "Your source RDS DB details",
@@ -142,9 +139,9 @@
     {
       "myComment" : "Default Pipeline object that defines IAM roles, pipeline log bucket path and Schedule",
       "failureAndRerunMode": "CASCADE",
-      "resourceRole": "DataPipelineDefaultResourceRole",
-      "role": "DataPipelineDefaultRole",
-      "pipelineLogUri": "s3://testbucket/logs/",
+      "resourceRole": "mosaics-data-pipeline-resources",
+      "role": "mosaics-data-pipeline",
+      "pipelineLogUri": "s3://data-pipeline-ew1/logs/",
       "scheduleType": "ONDEMAND",
       "name": "Default",
       "id": "Default"
@@ -244,19 +241,5 @@
       "id": "myRedshiftJdbcConnectStr",
       "type": "String"
     }
-  ],
-  "values": {
-    "myRedshiftUsername": "",
-    "myRDSUsername": "",
-    "myS3StagingLoc": "",
-    "myRedshiftJdbcConnectStr": "",
-    "*myRedshiftPassword": "",
-    "myInsertMode": "",
-    "myRDSJdbcConnectStr": "",
-    "myRDSRedshiftSecurityGrps": "",
-    "*myRDSPassword": "",
-    "myRedshiftTableName": "",
-    "myRDSTableName": "",
-    "myRedshiftTablePrimaryKey": ""
-  }
+  ]
 }


### PR DESCRIPTION
- S3 bucket is `data-pipeline-ew1` which is where shell script `dbconv_psqlRDStoRedshift.sh` is stored (if making changes to this file, need to re-upload to S3)
- if changes are made to pipeline definition `postgresqlRDS-to-Redshift-definition.json` or `myValues.json`, 

```
aws datapipeline put-pipeline-definition --pipeline-id <pipeline-id>   --pipeline-definition file:///path/to/aws-support-tools/DataPipeline/PostgresqlRdsToRedshift/postgresqlRDS-to-Redshift-definition.json --parameter-values-uri file:///path/to/aws-support-tools/DataPipeline/PostgresqlRdsToRedshift/myValues.json    --profile <aws-data-pipeline-profile>
```

to propagate the changes, where `<aws-data-pipeline-profile>` is in `~/.aws/config` with credentials for `mosaics-data-pipeline` user

- current pipeline has an instance `i-08e14238081a52b21`